### PR TITLE
Fix IntelliJ 24.2 bugs

### DIFF
--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="DevKit" />
+  </component>
+</project>

--- a/.idea/runConfigurations/OpenCMS_IntelliJ_plugin.xml
+++ b/.idea/runConfigurations/OpenCMS_IntelliJ_plugin.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="OpenCMS IntelliJ plugin" type="#org.jetbrains.idea.devkit.run.PluginConfigurationType">
+    <module name="opencms-intellijplugin" />
+    <option name="VM_PARAMETERS" value="-Xmx4096m -Xms2048m -ea" />
+    <option name="PROGRAM_PARAMETERS" value="" />
+    <predefined_log_file enabled="true" id="idea.log" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/src/com/mediaworx/intellij/opencmsplugin/OpenCmsPlugin.java
+++ b/src/com/mediaworx/intellij/opencmsplugin/OpenCmsPlugin.java
@@ -773,7 +773,7 @@ public class OpenCmsPlugin implements ProjectComponent, PersistentStateComponent
 		if (toolWindow == null) {
 			OpenCmsPluginConfigurationData config = getPluginConfiguration();
 			toolWindow = toolWindowManager.registerToolWindow(OpenCmsPlugin.TOOLWINDOW_ID, false, ToolWindowAnchor.BOTTOM);
-			toolWindow.setIcon(new ImageIcon(this.getClass().getResource("/icons/opencms_13.png")));
+//			toolWindow.setIcon(new ImageIcon(this.getClass().getResource("/icons/opencms_13.png")));
 			toolWindow.setAvailable(config != null && config.isOpenCmsPluginEnabled(), null);
 			OpenCmsPluginToolWindowFactory toolWindowFactory = new OpenCmsPluginToolWindowFactory();
 			toolWindowFactory.createToolWindowContent(project, toolWindow);

--- a/src/com/mediaworx/intellij/opencmsplugin/actions/menus/OpenCmsMainMenu.java
+++ b/src/com/mediaworx/intellij/opencmsplugin/actions/menus/OpenCmsMainMenu.java
@@ -233,7 +233,10 @@ public class OpenCmsMainMenu extends OpenCmsMenu {
 	 * so it is explicitly disabled.
 	 * @return always returns <code>false</code>
 	 */
+	/*
+	Disable to avoid java: method does not override or implement a method from a supertype
 	@Override
+	 */
 	public boolean disableIfNoVisibleChildren() {
 		return false;
 	}

--- a/src/com/mediaworx/intellij/opencmsplugin/actions/menus/OpenCmsMenu.java
+++ b/src/com/mediaworx/intellij/opencmsplugin/actions/menus/OpenCmsMenu.java
@@ -107,7 +107,10 @@ public abstract class OpenCmsMenu extends DefaultActionGroup {
 	 * see {@link OpenCmsMainMenu#update(AnActionEvent)}.
 	 * @return  always returns <code>true</code>
 	 */
+	/*
+	Disable to avoid java: method does not override or implement a method from a supertype
 	@Override
+	 */
 	public boolean disableIfNoVisibleChildren() {
 		return true;
 	}


### PR DESCRIPTION
These commits fix the crash issue #12 and makes the project compile again.

Unfortunately testing/packaging is only possible by compiling it with Java 17 as the IntelliJ classfiles otherwise cause the compiler to bail out with "class file has wrong version 61.0, should be 52.0" and then manually replacing the contents of the existing JAR file in `opencms-intellijplugin.zip/lib/opencms-intellijplugin.jar` with what comes out in `out`.

Short-term the project has to migrate to the Gradle plugin (https://plugins.jetbrains.com/docs/intellij/developing-plugins.html#gradle-plugin) and mid-term, follow-up the changes in `DefaultActionGroup. disableIfNoVisibleChildren` (see https://github.com/JetBrains/intellij-community/commit/d9839e254bc5c14dcd15de41d6670707d3c73aef) as well as the 49 currently unfixed deprecations.

I may or may not have time to tackle that myself, so can't make many promises for the next weeks, but that's how I at least got basic synchronisation working again.